### PR TITLE
ci: force more Playwright workers to fix slow CI runs

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -44,7 +44,11 @@ jobs:
       - name: Install Playwright Browsers
         run: pnpm exec playwright install --with-deps
       - name: Run Playwright tests
-        run: pnpm exec playwright test
+        # This runner only gets 1 worker by Playwright's CPU-based default,
+        # which serializes all 150 test instances (30 tests x 5 browser
+        # projects) and made the job run 25+ minutes instead of ~2. Force more
+        # parallelism explicitly.
+        run: pnpm exec playwright test --workers=4
         env:
           TWILIO_ACCOUNT_SID: ${{ vars.TWILIO_ACCOUNT_SID }}
           TWILIO_API_KEY: ${{ secrets.TWILIO_API_KEY }}


### PR DESCRIPTION
## Summary
The previous push to main (`f034be7`, done accidentally due to a branch-tracking footgun — now fixed locally) fixed the vitest 401 auth issue, and the resulting Tests run confirmed vitest now passes. But it also surfaced that Playwright only gets **1 worker** on this org's `ubuntu-x64` runner, serializing all 150 test instances (30 tests x 5 browser projects). That turned a ~2 minute local run into a 25+ minute CI run (still going when cancelled for investigation, well under the 60 min job timeout but no longer of that duration).

This forces `--workers=4` explicitly.

## Test plan
- [ ] Confirm the Tests workflow completes in a few minutes instead of 25+