### PR TITLE
feat: add Espresso with Chantilly to barista menu

### DIFF
--- a/src/components/icon-map.tsx
+++ b/src/components/icon-map.tsx
@@ -88,6 +88,7 @@ const iconMap: { [key: string]: any } = {
   "Strawberry Lemonade Tea": CupIcon,
   "Cold Brew": CupIcon,
   Moka: FlatWhiteIcon,
+  "Espresso Chantilly": EspressoIcon,
   "Matcha Green Tea": CupIcon,
   "Cucumber Juice": CupIcon,
   Nuttello: WaffleIcon,

--- a/src/config/menus.ts
+++ b/src/config/menus.ts
@@ -235,6 +235,11 @@ export default {
         title: "Moka",
         description: "Stovetop-brewed coffee, rich and strong",
       },
+      {
+        shortTitle: "Espresso Chantilly",
+        title: "Espresso with Chantilly",
+        description: "Espresso topped with a dollop of vanilla Chantilly cream",
+      },
     ],
     modifiers: [
       "Decaf",


### PR DESCRIPTION
Adds "Espresso with Chantilly" as a standalone item in the barista menu.

## Test plan
- [x] `pnpm build` passes
- [x] Unit tests pass
- [x] TypeScript compiles with no errors