### PR TITLE
feat: use pickupLocation in welcome message and AI prompt

### DIFF
--- a/src/app/(layout-free)/event/[slug]/kiosk/page.tsx
+++ b/src/app/(layout-free)/event/[slug]/kiosk/page.tsx
@@ -31,7 +31,7 @@ export default async function KioskPage(props: {
     return (
       <div className="p-4 space-y-8 flex-1">
         <p className="text-xl md:text-4xl">
-          Order your beverage here and pick it up at the {(event?.data as any)?.pickupLocation || "Twilio booth"}.
+          Order your beverage here and pick it up at {(event?.data as any)?.pickupLocation || "the Twilio booth"}.
         </p>
         {hasPermissions && (
           <OrderForm

--- a/src/app/(layout-free)/event/[slug]/kiosk/page.tsx
+++ b/src/app/(layout-free)/event/[slug]/kiosk/page.tsx
@@ -31,7 +31,7 @@ export default async function KioskPage(props: {
     return (
       <div className="p-4 space-y-8 flex-1">
         <p className="text-xl md:text-4xl">
-          Order your beverage here and pick it up at the Twilio booth.
+          Order your beverage here and pick it up at the {(event?.data as any)?.pickupLocation || "Twilio booth"}.
         </p>
         {hasPermissions && (
           <OrderForm

--- a/src/app/(master-layout)/event/[slug]/page.tsx
+++ b/src/app/(master-layout)/event/[slug]/page.tsx
@@ -404,6 +404,13 @@ function EventPage({ params }: { params: Promise<{ slug: string }> }) {
                 {touched.pickupLocation && fieldErrors.pickupLocation && (
                   <p className="text-xs text-red-500">{fieldErrors.pickupLocation}</p>
                 )}
+                {internalEvent.pickupLocation.length >= 3 && (
+                  <p className="text-xs text-gray-400 italic">
+                    {(internalEvent.language ?? "en") === "pt-BR"
+                      ? `"Bem-vindo ao ${internalEvent.pickupLocation}!"`
+                      : `"Welcome to ${internalEvent.pickupLocation}!"`}
+                  </p>
+                )}
               </div>
               <div className="space-y-1.5">
                 <Label htmlFor="language">Language</Label>

--- a/src/app/(master-layout)/event/[slug]/page.tsx
+++ b/src/app/(master-layout)/event/[slug]/page.tsx
@@ -404,13 +404,15 @@ function EventPage({ params }: { params: Promise<{ slug: string }> }) {
                 {touched.pickupLocation && fieldErrors.pickupLocation && (
                   <p className="text-xs text-red-500">{fieldErrors.pickupLocation}</p>
                 )}
-                {internalEvent.pickupLocation.length >= 3 && (
-                  <p className="text-xs text-gray-400 italic">
-                    {(internalEvent.language ?? "en") === "pt-BR"
+                <p className="text-xs text-gray-400 italic">
+                  {internalEvent.pickupLocation.length >= 3
+                    ? (internalEvent.language ?? "en") === "pt-BR"
                       ? `"Bem-vindo ao ${internalEvent.pickupLocation}!"`
-                      : `"Welcome to ${internalEvent.pickupLocation}!"`}
-                  </p>
-                )}
+                      : `"Welcome to ${internalEvent.pickupLocation}!"`
+                    : (internalEvent.language ?? "en") === "pt-BR"
+                      ? `"Bem-vindo ao Estande da Twilio!"`
+                      : `"Welcome to the Twilio Booth!"`}
+                </p>
               </div>
               <div className="space-y-1.5">
                 <Label htmlFor="language">Language</Label>

--- a/src/app/webhooks/messaging/ai-agent.ts
+++ b/src/app/webhooks/messaging/ai-agent.ts
@@ -269,7 +269,7 @@ Rules:
 * Always reply in ${languageName}, regardless of what language the user writes in.
 * When suggesting menu items, ALWAYS format them as a markdown list.
 * Never fabricate information on tool execution failures. Acknowledge errors without speculation.
-* If the users want to learn more about Twilio, point them to the Twilio employees at the booth.
+* If the users want to learn more about Twilio, point them to the Twilio employees at ${event.pickupLocation || "the booth"}.
 * If they want to reach out to sales, point them to https://www.twilio.com/en-us/help/sales
 * UNDER NO CIRCUMSTANCES TALK ABOUT TWILIO COMPETITORS. If asked, say you can't help with that and suggest they ask a Twilion.
 * Use the log_feedback tool if the user asks for something you cannot do. This stores their attempted action so we can improve the system.`;

--- a/src/app/webhooks/messaging/route.ts
+++ b/src/app/webhooks/messaging/route.ts
@@ -118,7 +118,7 @@ async function selectEventForCustomer(
 
     const welcomeMsg = isReturning
       ? getWelcomeBackMessage(newEvent.selection.mode, newEvent.name, newEvent.welcomeMessage, eventLang(newEvent))
-      : getWelcomeMessage(newEvent.selection.mode, newEvent.welcomeMessage, newEvent.leadCollection, eventLang(newEvent));
+      : getWelcomeMessage(newEvent.selection.mode, newEvent.welcomeMessage, newEvent.leadCollection, eventLang(newEvent), newEvent.pickupLocation);
     sendMessage(sender, welcomeMsg, undefined, undefined, from);
 
     const country = getCountryFromPhone(sender);
@@ -157,7 +157,7 @@ async function selectEventForCustomer(
     const newEvent = matches[0].data as Event;
     const welcomeMsg = isReturning
       ? getWelcomeBackMessage(newEvent.selection.mode, newEvent.name, newEvent.welcomeMessage, eventLang(newEvent))
-      : getWelcomeMessage(newEvent.selection.mode, newEvent.welcomeMessage, newEvent.leadCollection, eventLang(newEvent));
+      : getWelcomeMessage(newEvent.selection.mode, newEvent.welcomeMessage, newEvent.leadCollection, eventLang(newEvent), newEvent.pickupLocation);
     sendMessage(sender, welcomeMsg, undefined, undefined, from);
 
     const country = getCountryFromPhone(sender);

--- a/src/lib/stringTemplates.ts
+++ b/src/lib/stringTemplates.ts
@@ -73,10 +73,12 @@ export function getWelcomeMessage(
   customWelcomeMessage?: string,
   leadCollection: LeadCollection = "NONE",
   language: Language = "en",
+  pickupLocation?: string,
 ) {
+  const location = pickupLocation || (language === "pt-BR" ? "Estande da Twilio" : "Twilio Booth");
   const defaultWelcome = language === "pt-BR"
-    ? `Bem-vindo ao Estande da Twilio! Está pronto para um ${modeToBeverage(mode, language)} por nossa conta? 🎉`
-    : `Welcome to the Twilio Booth! Are you ready for a ${modeToBeverage(mode, language)} on us? 🎉`;
+    ? `Bem-vindo ao ${location}! Está pronto para um ${modeToBeverage(mode, language)} por nossa conta? 🎉`
+    : `Welcome to the ${location}! Are you ready for a ${modeToBeverage(mode, language)} on us? 🎉`;
 
   const welcomeMessage = customWelcomeMessage || defaultWelcome;
 

--- a/src/lib/stringTemplates.ts
+++ b/src/lib/stringTemplates.ts
@@ -75,10 +75,13 @@ export function getWelcomeMessage(
   language: Language = "en",
   pickupLocation?: string,
 ) {
-  const location = pickupLocation || (language === "pt-BR" ? "Estande da Twilio" : "Twilio Booth");
-  const defaultWelcome = language === "pt-BR"
-    ? `Bem-vindo ao ${location}! Está pronto para um ${modeToBeverage(mode, language)} por nossa conta? 🎉`
-    : `Welcome to the ${location}! Are you ready for a ${modeToBeverage(mode, language)} on us? 🎉`;
+  const defaultWelcome = pickupLocation
+    ? language === "pt-BR"
+      ? `Bem-vindo ao ${pickupLocation}! Está pronto para um ${modeToBeverage(mode, language)} por nossa conta? 🎉`
+      : `Welcome to ${pickupLocation}! Are you ready for a ${modeToBeverage(mode, language)} on us? 🎉`
+    : language === "pt-BR"
+      ? `Bem-vindo ao Estande da Twilio! Está pronto para um ${modeToBeverage(mode, language)} por nossa conta? 🎉`
+      : `Welcome to the Twilio Booth! Are you ready for a ${modeToBeverage(mode, language)} on us? 🎉`;
 
   const welcomeMessage = customWelcomeMessage || defaultWelcome;
 


### PR DESCRIPTION
## Summary
- Welcome message, AI agent prompt, and kiosk page now use the event's Pickup Location instead of hardcoded "Booth"/"Estande"
- Custom locations omit the article ("Welcome to Twilio Coworking" not "Welcome to the Twilio Coworking")
- Falls back to original defaults when no Pickup Location is set
- Admin UI shows a live preview of the welcome message under the Pickup Location field

## How to test

**Welcome message preview (admin UI):**
1. Go to `/event/febraban-tech-2026` admin page
2. Look under the Pickup Location field — you should see a preview sentence
3. Clear the field → preview shows the default ("Welcome to the Twilio Booth!")
4. Type "Twilio Coworking" → preview updates to "Welcome to Twilio Coworking!"
5. Change language to "Português (Brasil) → preview shows "Bem-vindo ao Twilio Coworking!"

**Welcome message (WhatsApp):**
1. Set Pickup Location to "Twilio Coworking" on an event
2. Send a message to the WhatsApp sender for that event from a new number
3. Confirm the welcome says "Bem-vindo ao Twilio Coworking!" (pt-BR) or "Welcome to Twilio Coworking!" (en)

**Kiosk page:**
1. Visit `/event/febraban-tech-2026/kiosk`
2. Confirm it says "pick it up at Twilio Coworking" (or "the Twilio booth" if no location is set)

**AI agent:**
1. After ordering, ask "Where can I learn more about Twilio?"
2. Confirm the agent says "at Twilio Coworking" (not "at the booth")