### PR TITLE
feat: use macchiato-style icon for Espresso Chantilly

### DIFF
--- a/src/components/icon-map.tsx
+++ b/src/components/icon-map.tsx
@@ -19,6 +19,7 @@ import {
   BerryWaffleIcon,
   WhiteWineIcon,
   SmoothieAppleIcon,
+  EspressoChantillyIcon,
 } from "@/components/icons";
 
 const iconMap: { [key: string]: any } = {
@@ -88,7 +89,7 @@ const iconMap: { [key: string]: any } = {
   "Strawberry Lemonade Tea": CupIcon,
   "Cold Brew": CupIcon,
   Moka: FlatWhiteIcon,
-  "Espresso Chantilly": EspressoIcon,
+  "Espresso Chantilly": EspressoChantillyIcon,
   "Matcha Green Tea": CupIcon,
   "Cucumber Juice": CupIcon,
   Nuttello: WaffleIcon,

--- a/src/components/icons.tsx
+++ b/src/components/icons.tsx
@@ -2823,6 +2823,8 @@ export function EspressoMacchiatoIcon(props: any) {
   );
 }
 
+export const EspressoChantillyIcon = EspressoMacchiatoIcon;
+
 export function EspressoMachineIcon2(props: any) {
   return (
     <svg


### PR DESCRIPTION
## Summary
- Creates `EspressoChantillyIcon` as a named alias for `EspressoMacchiatoIcon` (smaller cup with topping)
- Updates icon-map to use the new alias instead of `EspressoIcon`

The macchiato icon better represents a cream-topped espresso visually, and the alias keeps the code self-documenting without duplicating SVG.

## Test plan
- [x] TypeScript compiles with no errors
- [ ] Verify icon renders on the menu kiosk (/event/febraban-tech-2026/menu) for the Espresso Chantilly item